### PR TITLE
Fixing ArgoCD CR: Cannot specify both keycloak and dex

### DIFF
--- a/bootstrap/roles/ocp4-install-gitops/templates/gitops-argocd.yaml.j2
+++ b/bootstrap/roles/ocp4-install-gitops/templates/gitops-argocd.yaml.j2
@@ -34,7 +34,9 @@ spec:
       enabled: false
   initialSSHKnownHosts: {}
   sso:
-    provider: keycloak
+    provider: dex
+    dex:
+      openShiftOAuth: true
   applicationSet:
     resources:
       limits:
@@ -55,8 +57,6 @@ spec:
       kinds:
       - TaskRun
       - PipelineRun
-  dex:
-    openShiftOAuth: true
   ha:
     enabled: false
     resources:


### PR DESCRIPTION
We cannot specify both keycloak and dex as SSO providers. When I tried enabling just keycloak the gitops-operator hit some segfault errors so switch to just using dex for now